### PR TITLE
deploy to github pages action template

### DIFF
--- a/workflow-templates/deploy-gh-pages.properties.json
+++ b/workflow-templates/deploy-gh-pages.properties.json
@@ -1,0 +1,6 @@
+{
+	"name": "DEGJS Deploy to Github Pages",
+	"description": "DEGJS CI workflow template for deploying a demo project to Github Pages.",
+	"iconName": "default",
+	"categories": ["JavaScript"]
+}

--- a/workflow-templates/deploy-gh-pages.yml
+++ b/workflow-templates/deploy-gh-pages.yml
@@ -1,0 +1,25 @@
+# This workflow will do a clean install of node dependencies, build a demo project, and deploy it to Github Pages
+
+name: Deploy to Github Pages
+on:
+  push:
+    branches: [$default-branch]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false 
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm run-script build-demo
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: demo/dist


### PR DESCRIPTION
This PR adds a Github Action template for deploying a demo project to Github Pages. It's using the [Deploy to Github Pages](https://github.com/marketplace/actions/deploy-to-github-pages) behind the scenes.